### PR TITLE
Make overlay layer ABOVE_SCENE

### DIFF
--- a/src/main/java/com/playertile/PlayerTileOverlay.java
+++ b/src/main/java/com/playertile/PlayerTileOverlay.java
@@ -24,7 +24,7 @@ public class PlayerTileOverlay extends Overlay
     PlayerTileOverlay(Client client, PlayerTilePlugin plugin, PlayerTileConfig config)
     {
         setPosition(OverlayPosition.DYNAMIC);
-        setLayer(OverlayLayer.ABOVE_WIDGETS);
+        setLayer(OverlayLayer.ABOVE_SCENE);
         this.client = client;
         this.plugin = plugin;
         this.config = config;


### PR DESCRIPTION
The main reason I have this plugin turned off is because it appears above the bank interface which imo hinders player experience, at least it hinders mine.